### PR TITLE
feat(cli): add version command and build-time version injection

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,8 +6,13 @@ CGO_ENABLED := 1
 help: ## Show this help
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*?## "}; {printf "  \033[36m%-10s\033[0m %s\n", $$1, $$2}'
 
+VERSION := $(shell git describe --tags --always --dirty 2>/dev/null || echo "dev")
+COMMIT  := $(shell git rev-parse --short HEAD 2>/dev/null || echo "unknown")
+DATE    := $(shell date -u +%Y-%m-%d)
+LDFLAGS := -X main.version=$(VERSION) -X main.commit=$(COMMIT) -X main.buildDate=$(DATE)
+
 build: ## Build binary to bin/jorm
-	CGO_ENABLED=$(CGO_ENABLED) go build -o bin/jorm ./cmd/jorm
+	CGO_ENABLED=$(CGO_ENABLED) go build -ldflags "$(LDFLAGS)" -o bin/jorm ./cmd/jorm
 
 run: ## Run via go run (use ARGS="run 42")
 	CGO_ENABLED=$(CGO_ENABLED) go run ./cmd/jorm $(ARGS)

--- a/cmd/jorm/main.go
+++ b/cmd/jorm/main.go
@@ -24,6 +24,13 @@ import (
 	"github.com/jorm/internal/tui"
 )
 
+// Set via -ldflags at build time.
+var (
+	version   = "dev"
+	commit    = "unknown"
+	buildDate = "unknown"
+)
+
 func main() {
 	var (
 		configPath string
@@ -422,6 +429,15 @@ func main() {
 	configCmd.Flags().BoolVar(&validateConfig, "validate", false, "validate config file")
 	configCmd.Flags().StringVar(&workflowName, "workflow", "", "show agents for a workflow template")
 
+	// Version command
+	versionCmd := &cobra.Command{
+		Use:   "version",
+		Short: "Print version information",
+		Run: func(cmd *cobra.Command, args []string) {
+			fmt.Printf("jorm %s (commit: %s, built: %s)\n", version, commit, buildDate)
+		},
+	}
+
 	// Init command (stub)
 	initCmd := &cobra.Command{
 		Use:   "init",
@@ -433,7 +449,7 @@ func main() {
 		},
 	}
 
-	root.AddCommand(runCmd, resumeCmd, listCmd, statusCmd, logsCmd, stopCmd, cleanCmd, inspectCmd, configCmd, initCmd)
+	root.AddCommand(runCmd, resumeCmd, listCmd, statusCmd, logsCmd, stopCmd, cleanCmd, inspectCmd, configCmd, initCmd, versionCmd)
 
 	if err := root.Execute(); err != nil {
 		os.Exit(1)


### PR DESCRIPTION
- Add `version` subcommand that prints version, commit, and build date
- Inject VERSION, COMMIT, DATE via -ldflags in Makefile build target
- Derive version from git tags with fallback to "dev"

Co-Authored-By: Claude <noreply@anthropic.com>
